### PR TITLE
Use interface to create logger

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -19,7 +19,7 @@ import (
 var timeFormat = "02/Jan/2006:15:04:05 -0700"
 
 // Logger is the logrus logger handler
-func Logger(log *logrus.Logger) gin.HandlerFunc {
+func Logger(logger logrus.FieldLogger) gin.HandlerFunc {
 	hostname, err := os.Hostname()
 	if err != nil {
 		hostname = "unknow"
@@ -40,7 +40,7 @@ func Logger(log *logrus.Logger) gin.HandlerFunc {
 			dataLength = 0
 		}
 
-		entry := logrus.NewEntry(log).WithFields(logrus.Fields{
+		entry := logger.WithFields(logrus.Fields{
 			"hostname":   hostname,
 			"statusCode": statusCode,
 			"latency":    latency, // time to process


### PR DESCRIPTION
By using the [`FieldLogger`](https://godoc.org/github.com/sirupsen/logrus#FieldLogger) interface the logger supports both new logrus loggers and existing field loggers such as an entry. This is useful if the enduser uses an existing logrus logger with default fields.

An example of how an existing logger would look like:

```go
logger := logrus.New().WithField(logrus.Fields{
    "service_name": "my-logging-service",
})

r.Use(ginlogrus.Logger(logger), gin.Recovery())
```