### PR TITLE
Fix logrus import statement in usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## Usage
 ```go
 import (
-  "github.com/Sirupsen/logrus"
+  "github.com/sirupsen/logrus"
   "github.com/toorop/gin-logrus"
   "github.com/gin-gonic/gin"
 


### PR DESCRIPTION
Small thing, but the usage section has the wrong case. From the logrus page:

> Seeing weird case-sensitive problems? It's in the past been possible to import Logrus as both upper- and lower-case. Due to the Go package environment, this caused issues in the community and we needed a standard. Some environments experienced problems with the upper-case variant, so the lower-case was decided. Everything using logrus will need to use the lower-case: github.com/sirupsen/logrus. Any package that isn't, should be changed.